### PR TITLE
surlignage des éléments personnes ou lieux sélectionnés

### DIFF
--- a/NDF_app/app/extraction.py
+++ b/NDF_app/app/extraction.py
@@ -45,10 +45,11 @@ def extraction_donnees(document):
         db.session.commit()
 
     # extraction et insertion des éléments concernants la table personne
-    # récupération sous forme de liste des éléments nom, prenom et role pour chaque personne présente dans le listPerson
+    # récupération sous forme de liste des éléments nom, prenom, role et pointeur pour chaque personne présente dans le listPerson
     element_nom_personne = document.xpath("//persName/surname/text()")
     element_prenom = document.xpath("//persName/forename/text()")
     element_role = document.xpath("//person/@role")
+    element_pointeur_pers = document.xpath("//person/@xml:id")
     n = 0
     for element in document.xpath("//particDesc//person"):
         # pour chaque person dans le listPerson, répétition des actions suivantes:
@@ -63,16 +64,18 @@ def extraction_donnees(document):
                             personne_prenom=element_prenom[int(n) - 1],
                             personne_dreyf=element_role_dreyf[0],
                             personne_role=element_role[int(n)-1],
-                            personne_notes=element_notes_personne
+                            personne_notes=element_notes_personne,
+                            personne_pointeur=element_pointeur_pers[int(n)-1]
                             )
         # ajout de Personne dans la base de données
         db.session.add(personne)
         # commit pour enregistrement de la modification
         db.session.commit()
     # extraction et insertion des éléments concernant la table Lieu
-    # récupération des éléments nom et descriptions sous la forme de listes pour tout les lieux
+    # récupération des éléments nom, pointeur et description sous la forme de listes pour tout les lieux
     element_nom_lieu = document.xpath("//place/placeName/text()")
     element_desc_lieu = document.xpath("//place/desc/text()")
+    element_pointeur_lieu = document.xpath("//place/@xml:id")
     n = 0
     for element in document.xpath("//listPlace/place"):
         #pour chaque lieu contenu dans le listPlace, réitération de ces actions:
@@ -83,7 +86,8 @@ def extraction_donnees(document):
         # création de l'objet lieu un nouveau Lieu ayant pour attributs les éléments suivants
         lieu = Lieu(lieu_nom=element_nom_lieu[int(n) - 1],
                     lieu_notes=element_desc_lieu[int(n) - 1],
-                    lieu_emplacement=element_localisation
+                    lieu_emplacement=element_localisation,
+                    lieu_pointeur=element_pointeur_lieu[int(n)-1]
                     )
         # ajout de l'objet lieu dans la base de données
         db.session.add(lieu)

--- a/NDF_app/app/modeles/donnees.py
+++ b/NDF_app/app/modeles/donnees.py
@@ -51,6 +51,7 @@ class Personne(db.Model):
     personne_dreyf = db.Column(db.String(45))
     personne_role = db.Column(db.String(45))
     personne_notes = db.Column(db.Text)
+    personne_pointeur=db.Column(db.String(45))
 
 
 # définition de la classe Lieu sur le même modèle que les classes précédentes
@@ -62,4 +63,5 @@ class Lieu(db.Model):
     lieu_nom = db.Column(db.String(45), nullable=False)
     lieu_emplacement = db.Column(db.String(63))
     lieu_notes = db.Column(db.Text)
+    lieu_pointeur = db.Column(db.String(45))
 

--- a/NDF_app/app/routes.py
+++ b/NDF_app/app/routes.py
@@ -16,6 +16,7 @@ dans l'ordre:
 from flask import render_template, request
 from itertools import groupby
 from flask_paginate import Pagination, get_page_parameter, get_page_args
+from lxml import etree
 
 # import des classes app et db depuis le module app
 from .app import app,db
@@ -68,6 +69,25 @@ def note(article_id):
     unique_note=Article.query.get(article_id)
     # application de la feuille de transformation xslt_transformation au document xml uniquement pour l'article choisi
     affichage_texte = xslt_transformation(document_xml, num=str(article_id))
+    return render_template("pages/note.html", note=unique_note, texte=str(affichage_texte))
+
+
+@app.route("/corpus/<article_id>/<pointeur>")
+def surlignage(article_id, pointeur):
+    """
+        Route permettant l'affichage d'un article demandé depuis un des index (de lieux ou de personnes) avec l'élément cherché surligné.
+        :param article_id: identifiant unique représentant un article en particulier
+        :type article_id: int
+        :param pointeur: chaine de caractères représentant un personnage ou lieu précis
+        :type pointeur: str
+        :return: template note.html
+        :rtype: template
+        """
+    # récupération de l'article ayant pour identifiant l'entier article_id
+    unique_note = Article.query.get(article_id)
+    # application de la feuille de transformation xslt_transformation au document xml uniquement pour l'article
+    # choisi et pour le pointeur (lieu ou personnage) choisi.
+    affichage_texte = xslt_transformation(document_xml, num=etree.XSLT.strparam(article_id), pointeur=etree.XSLT.strparam(pointeur))
     return render_template("pages/note.html", note=unique_note, texte=str(affichage_texte))
 
 

--- a/NDF_app/app/templates/conteneur.html
+++ b/NDF_app/app/templates/conteneur.html
@@ -4,14 +4,14 @@
 
     <head>
         <meta charset="UTF-8">
-        <title>Notes d'une frondeuse {%block titre%}{%endblock%}</title>
+        <title>Notes d'une frondeuse</title>
         {% include "partials/metadata.html" %}
         {% include "partials/css.html"%}
         <link rel="icon" href="data:,">
     </head>
 
-    <body>
-		<nav class="navbar navbar-expand-lg" role="navigation">
+    <body style="background-color: #E4D5D3">
+		<nav class="navbar navbar-expand-lg navbar-light rounded shadow" role="navigation" style="background-color: #FF5C39">
 			<a href="{{ url_for('accueil') }}">Accueil</a>
 			<div class="container-fluid">
         		<ul class="navbar-nav mr-auto">
@@ -39,5 +39,22 @@
                 {% block corps%}{%endblock%}
         </div>
     </body>
+	<footer class="page-footer">
+    <div class="container">
+
+		<span><a href="{{url_for('about')}}">À propos du projet</a></span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                    <span><a href="{{url_for('contexte')}}">À propos de Notes d'une frondeuse</a></span>
+            </div>
+
+
+
+    <!-- Copyright -->
+    <div class="footer-copyright text-center">
+        <p>© Notes d'une Frondeuse - Juliette Janes</p>
+        <a href="http://www.chartes.psl.eu/fr" target="_blank">Ecole nationale des Chartes</a>
+    </div>
+    <!-- Copyright -->
+
+</footer>
 </html>
     

--- a/NDF_app/app/templates/pages/index_lieu.html
+++ b/NDF_app/app/templates/pages/index_lieu.html
@@ -28,7 +28,7 @@
 							{% for key, value in dict.items() %}
                             <tr scope="row">
                                 <td>{{key.lieu_nom}}</td>
-                                <td><ul>{%for el in value %}<li><a href="{{url_for('note', article_id=el.article_id)}}">{{el.article_date}}</a></li>{% endfor %}</ul></td>
+                                <td><ul>{%for el in value %}<li><a href="{{url_for('surlignage', article_id=el.article_id, pointeur=key.lieu_pointeur)}}">{{el.article_date}}</a></li>{% endfor %}</ul></td>
                                 <td>{{key.lieu_emplacement}}</td>
 								<td>{{key.lieu_notes}}</td>
                             </tr>

--- a/NDF_app/app/templates/pages/index_pers.html
+++ b/NDF_app/app/templates/pages/index_pers.html
@@ -28,7 +28,7 @@
 							{% for key, value in dict.items() %}
                             <tr scope="row">								
                                 <td>{{key.personne_nom}}</td>
-                                <td><ul>{%for el in value %}<li><a href="{{url_for('note', article_id=el.article_id)}}">{{el.article_date}}</a></li>{% endfor %}</ul></td>
+                                <td><ul>{%for el in value %}<li><a href="{{url_for('surlignage', article_id=el.article_id, pointeur=key.personne_pointeur)}}">{{el.article_date}}</a></li>{% endfor %}</ul></td>
                                 <td>{{key.personne_dreyf}} et {{key.personne_role}}</td>
 								<td>{{key.personne_notes}}</td>								
                             </tr>

--- a/NDF_app/app/xml_tei/xslt_affichage_note.xsl
+++ b/NDF_app/app/xml_tei/xslt_affichage_note.xsl
@@ -4,11 +4,20 @@
     <xsl:output method="html" indent="yes" encoding="UTF-8"/>
         
     <xsl:strip-space elements="*"/> <!-- pour éviter les espaces non voulus -->
-       
+    
+    <!--définition des différents paramètres possibles à ajouter depuis routes.py-->
+    <!--identifiant permettant de sélectionner l'article voulu-->
     <xsl:param name="num"/>
-    <xsl:variable name="note" select="descendant::text[@n=2]"/>
+    <!--pointeur pour surligner un élément (lieu ou personne) dans la route surlignage-->
+    <xsl:param name="pointeur"/>
+ 
+    
+    <!--récupération de l'article choisi-->
+    <xsl:variable name="note" select="descendant::text[@n=$num]"/>
      
+     <!--construction de la structure html-->
     <xsl:template match="TEI">
+        <br/>
         <xsl:element name="span">
             <xsl:element name="a">
                 <xsl:attribute name="href">
@@ -22,6 +31,7 @@
         <xsl:apply-templates select="$note//div"/>
     </xsl:template>
     
+    <!--structuration des éléments autour des paragraphes (opener, closer, postcript et quote)-->
     <xsl:template match="opener">
         <xsl:element name="div">
             <xsl:attribute name="align">
@@ -60,20 +70,62 @@
         </xsl:element>
         </xsl:element>
     </xsl:template>
-     <xsl:template match="div//p">
-         <xsl:element name="p">
-            <xsl:text>&#160; &#160;</xsl:text>
-             <xsl:value-of select="."/>
-         </xsl:element>
-     </xsl:template>
-    <xsl:template match="div//dateline">
-        <xsl:element name="span">
-            <xsl:value-of select="."/>
-        </xsl:element>
-    </xsl:template>
     <xsl:template match="quote">
         <xsl:element name="blockquote">
             <xsl:apply-templates select="p"/>
         </xsl:element>
     </xsl:template>
+
+<!--structuration de la dateline-->
+    <xsl:template match="div//dateline">
+        <xsl:element name="span">
+            <xsl:value-of select="."/>
+        </xsl:element>
+    </xsl:template>
+    <!--structuration des paragraphes avec des alinéas-->
+     <xsl:template match="div//p">
+         <xsl:element name="p">
+            <xsl:text>&#160; &#160;</xsl:text>
+             <xsl:apply-templates select="node()"/>
+         </xsl:element>
+     </xsl:template>
+    <!--structuration des éléments à l'intérieur des paragraphes
+        on les intègre grâce à select node() qui permet de sélectionner le noeud
+        sur lequel on a match-->
+    <xsl:template match="hi">
+        <xsl:element name="i">
+            <xsl:apply-templates select="node()"/>
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="persName">
+        <xsl:choose>
+            <xsl:when test="translate(@ref,'#','')=$pointeur">
+                <xsl:element name="span">
+                    <xsl:attribute name="style">
+                        <xsl:text>background-color:red</xsl:text>
+                    </xsl:attribute>
+                    <xsl:apply-templates select="node()"/>
+                </xsl:element>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="node()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    <xsl:template match="placeName">
+          <xsl:choose>
+            <xsl:when test="translate(@ref,'#','')=$pointeur">
+                <xsl:element name="span">
+                    <xsl:attribute name="style">
+                        <xsl:text>background-color:red</xsl:text>
+                    </xsl:attribute>
+                    <xsl:apply-templates select="node()"/>
+                </xsl:element>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="node()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>    
+
 </xsl:stylesheet>


### PR DESCRIPTION
Travail sur le lien entre les index à la page article associée afin de mettre en valeur la personne ou le lieu recherché.e
-ajout d'un attribut pointeur dans les tables personnes et lieux de la bdd, permettant de récupérer l'élément xml:id de person et place dans le Header
-création de règles xslt sur les persNames et placeName permettant, si l'attribut ref correspond à un pointeur entré en paramètre, de surligner cet élément
-création d'une nouvelle route corpus/<int:article_id>/<pointeur> et lien avec les articles dans les index dans le but de récupérer les pointeurs des personnes ou lieux que l'utilisateur recherche